### PR TITLE
change from fftshift to decenter

### DIFF
--- a/src/torch_subpixel_crop/subpixel_crop_2d.py
+++ b/src/torch_subpixel_crop/subpixel_crop_2d.py
@@ -15,7 +15,7 @@ def subpixel_crop_2d(
         sidelength: int,
         mask: Optional[torch.Tensor] = None,
         return_rfft: bool = False,
-        fftshifted: bool = False,
+        decenter: bool = False,
 ):
     """Extract square patches from 2D images with subpixel precision.
 
@@ -33,10 +33,10 @@ def subpixel_crop_2d(
     return_rfft : bool, default False
         If `True`, return the rft of the patches. It can save an FFT
          operation because the subpixel shift already requires an FFT.
-    fftshifted : bool, default False
-        In case the patches are returned as rft, optionally also apply a
-         fftshift. This is efficient because it can be applied together
-         with the subpixel shift.
+    decenter : bool, default False
+        In case the patches are returned as rft, optionally also apply an
+         additional shift of sidelength / 2 so that the real space image has its origin
+         at 0.
 
     Returns
     -------
@@ -62,7 +62,7 @@ def subpixel_crop_2d(
         output_image_sidelength=sidelength,
         mask=mask,
         return_rfft=return_rfft,
-        fftshifted=fftshifted,
+        decenter=decenter,
     )
 
     # Restore original shape
@@ -80,7 +80,7 @@ def _extract_patches_batched(
         output_image_sidelength: int,
         mask: Optional[torch.Tensor] = None,
         return_rfft: bool = False,
-        fftshifted: bool = False,
+        decenter: bool = False,
 ) -> torch.Tensor:  # (n, batch, ph, pw)
     batch, h, w = images.shape
     n_pos, batch_check, _ = positions.shape
@@ -143,6 +143,9 @@ def _extract_patches_batched(
         # fft the patches
         patches_dft = torch.fft.rfftn(patches, dim=(-2, -1))
 
+        if decenter:
+            shifts = shifts + pw / 2
+
         # apply the subpixel shift
         patches_dft = fourier_shift_dft_2d(
             dft=patches_dft,
@@ -151,9 +154,6 @@ def _extract_patches_batched(
             rfft=True,
             fftshifted=False,
         )
-
-        if fftshifted:
-            patches_dft = torch.fft.fftshift(patches_dft, dim=(-2,))
 
         return patches_dft
 

--- a/src/torch_subpixel_crop/subpixel_crop_2d.py
+++ b/src/torch_subpixel_crop/subpixel_crop_2d.py
@@ -32,11 +32,13 @@ def subpixel_crop_2d(
          or broadcastable to (..., b, size, size)
     return_rfft : bool, default False
         If `True`, return the rft of the patches. It can save an FFT
-         operation because the subpixel shift already requires an FFT.
+         operation because the subpixel shift already requires an FFT. The returned
+         rffts have their origin at (0, 0)
     decenter : bool, default False
         In case the patches are returned as rft, optionally also apply an
          additional shift of sidelength / 2 so that the real space image has its origin
-         at 0.
+         at 0. NOTE: this does not change the origin in Fourier space, the rffts
+         still have their origin at (0, 0)
 
     Returns
     -------

--- a/src/torch_subpixel_crop/subpixel_crop_3d.py
+++ b/src/torch_subpixel_crop/subpixel_crop_3d.py
@@ -38,11 +38,13 @@ def subpixel_crop_3d(
          or broadcastable to (..., b, size, size)
     return_rfft : bool, default False
         If `True`, return the rft of the patches. It can save an FFT
-         operation because the subpixel shift already requires an FFT.
+         operation because the subpixel shift already requires an FFT.The returned
+         rffts have their origin at (0, 0)
     decenter : bool, default False
         In case the patches are returned as rft, optionally also apply an
          additional shift of sidelength / 2 so that the real space image has its origin
-         at 0.
+         at 0. NOTE: this does not change the origin in Fourier space, the rffts
+         still have their origin at (0, 0)
 
     Returns
     -------

--- a/tests/test_subpixel_crop_2d.py
+++ b/tests/test_subpixel_crop_2d.py
@@ -36,13 +36,13 @@ def test_subpixel_crop_single_2d_return_rfft():
         positions=torch.tensor([5.5, 5.5]).float(),
         sidelength=4,
         return_rfft=True,
-        fftshifted=False,
+        decenter=False,
     )
     cropped_image_rfft = torch.fft.irfftn(cropped_image_rfft, s=(4, 4))
     assert torch.allclose(cropped_image_rfft, cropped_image_real)
 
 
-def test_subpixel_crop_single_2d_return_rfft_shifted():
+def test_subpixel_crop_single_2d_return_rfft_decenter():
     image = torch.zeros((10, 10))
     image[4:6, 4:6] = 1
 
@@ -52,17 +52,20 @@ def test_subpixel_crop_single_2d_return_rfft_shifted():
         sidelength=4
     )
 
-    cropped_image_fftshifted = subpixel_crop_2d(
+    cropped_image_decenter = subpixel_crop_2d(
         image=image,
         positions=torch.tensor([5.5, 5.5]).float(),
         sidelength=4,
         return_rfft=True,
-        fftshifted=True,
+        decenter=True,
     )
-    cropped_image_fftshifted = torch.fft.irfftn(
-        torch.fft.ifftshift(cropped_image_fftshifted, dim=(-2,)), s=(4, 4)
+    cropped_image_decenter = torch.fft.irfftn(
+        cropped_image_decenter, s=(4, 4)
     )
-    assert torch.allclose(cropped_image_fftshifted, cropped_image_real)
+    cropped_image_decenter = (
+        torch.fft.fftshift(cropped_image_decenter, dim=(-2, -1))
+    )
+    assert torch.allclose(cropped_image_decenter, cropped_image_real)
 
 
 def test_subpixel_crop_2d_with_fourier_shift():

--- a/tests/test_subpixel_crop_3d.py
+++ b/tests/test_subpixel_crop_3d.py
@@ -34,13 +34,13 @@ def test_subpixel_crop_single_3d_return_rfft():
         positions=torch.tensor([5.5, 5.5, 5.5]).float(),
         sidelength=4,
         return_rfft=True,
-        fftshifted=False,
+        decenter=False,
     )
     cropped_image_rfft = torch.fft.irfftn(cropped_image_rfft, s=(4, 4, 4))
     assert torch.allclose(cropped_image_rfft, cropped_image_real)
 
 
-def test_subpixel_crop_single_3d_return_rfft_shifted():
+def test_subpixel_crop_single_3d_return_rfft_decenter():
     image = torch.zeros((10, 10, 10))
     image[4:6, 4:6, 4:6] = 1
 
@@ -50,20 +50,20 @@ def test_subpixel_crop_single_3d_return_rfft_shifted():
         sidelength=4
     )
 
-    cropped_image_fftshifted = subpixel_crop_3d(
+    cropped_image_decenter = subpixel_crop_3d(
         image=image,
         positions=torch.tensor([5.5, 5.5, 5.5]).float(),
         sidelength=4,
         return_rfft=True,
-        fftshifted=True,
+        decenter=True,
     )
-    cropped_image_fftshifted = (
-        torch.fft.ifftshift(cropped_image_fftshifted, dim=(-3, -2,))
+    cropped_image_decenter = (
+        torch.fft.irfftn(cropped_image_decenter, s=(4, 4, 4))
     )
-    cropped_image_fftshifted = (
-        torch.fft.irfftn(cropped_image_fftshifted, s=(4, 4, 4))
+    cropped_image_decenter = (
+        torch.fft.fftshift(cropped_image_decenter, dim=(-3, -2, -1))
     )
-    assert torch.allclose(cropped_image_fftshifted, cropped_image_real)
+    assert torch.allclose(cropped_image_decenter, cropped_image_real)
 
 
 def test_subpixel_crop_multi_3d():


### PR DESCRIPTION
Changed previous fftshift functionality to do a decentering of the real space image simultaneously with the subpixel shift.

Specifically:
* getting the extracted patches back in Fourier space can be handy to save computation
* any fftshifted on the Fourier transform the user can do themselves and wont increase computation time
* for the case of reconstruction where the rotation of the patches is done in Fourier space, its important that the real space images have had an ifftshift applied so that their origin is at (0, 0). This is specifically the case that decenter fixes. This ifftshift is a phase shift of sidelength / 2 in Fourier space which can be easily combined with the subpixel shift.